### PR TITLE
OD-1974 [UPD] pglogical - using sqlparse to deduce DDL statements to replicate.

### DIFF
--- a/pglogical/__manifest__.py
+++ b/pglogical/__manifest__.py
@@ -10,4 +10,7 @@
     "author": "Hunki Enterprises BV, Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "post_load": "post_load",
+    'external_dependencies': {
+        'python': ['sqlparse'],
+    },
 }


### PR DESCRIPTION
@hbrunn @pankk  just a suggestion for usage of `sqlparse` as discussed, so we start testing this cool change internally (I merged the buildout branch already, but didn't think through this part so just including it here now).
 definitely will make deployments easier to coordinate! ^^